### PR TITLE
Strips username@ and only removes trailing .git from remote if it exists.

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,8 +122,8 @@ const setBranch = (actionCwd) => {
 
 // Current git remote
 const setRemote = (actionCwd) => {
-    exec(`git config --get remote.origin.url | sed -e 's/.git$//'`, { cwd: actionCwd }, (err, remote) => {
-        curRemote = /^https?:\/\//.test(remote) ? remote : '';
+    exec(`git config --get remote.origin.url`, { cwd: actionCwd }, (err, remote) => {
+        curRemote = /^https?:\/\//.test(remote) ? remote.replace(/.git$/, '') : '';
     })
 };
 


### PR DESCRIPTION
Edits as discussed in #2. Sometimes the remote URL doesn't actually contain ".git" so this approach uses regex to only remove the substring if it exists.