### PR TITLE
Trim trailing whitespace on remote URL.

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ const setBranch = (actionCwd) => {
 // Current git remote
 const setRemote = (actionCwd) => {
     exec(`git config --get remote.origin.url`, { cwd: actionCwd }, (err, remote) => {
-        curRemote = /^https?:\/\//.test(remote) ? remote.replace(/[A-z0-9\-]+@/, '').replace(/\.git/, '') : '';
+        curRemote = /^https?:\/\//.test(remote) ? remote.trim().replace(/[A-z0-9\-]+@/, '').replace(/\.git$/, '') : '';
     })
 };
 


### PR DESCRIPTION
This change trims trailing whitespace on the git remote URL before trying to strip the `.git` file extension — check if this works for the cases where it failed previously.