### PR TITLE
Change footerTransparent default to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const { exec } = require('child_process');
 // Config
 exports.decorateConfig = config => {
     var configObj = Object.assign({
-        footerTransparent: true,
+        footerTransparent: false,
         dirtyColor: config.colors.orange || config.colors.yellow,
     }, config.hyperStatusLine);
 


### PR DESCRIPTION
As [stated in the README](https://github.com/henrikdahl/hyper-statusline#disable-footer-transparency) - the default value of `footerTransparent` should be `false`.