### PR TITLE
update CWD when user press enter key

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,6 @@ let uids = {};
 const setCwd = (pid) => {
     exec(`lsof -p ${pid} | grep cwd | tr -s ' ' | cut -d ' ' -f9-`, (err, cwd) => {
         curCwd = cwd.trim();
-
         setBranch(curCwd);
     })
 };
@@ -220,6 +219,12 @@ exports.middleware = (store) => (next) => (action) => {
             uids[action.uid] = action.pid;
             curPid = action.pid;
             setCwd(curPid);
+            break;
+        case 'SESSION_ADD_DATA':
+            const { data } = action;
+            if (data.charCodeAt(0) === 13) {
+                setCwd(curPid)
+            }
             break;
         case 'SESSION_SET_ACTIVE':
             curPid = uids[action.uid];


### PR DESCRIPTION
The current implementation only updates the CWD when Session is activated (by switching tabs or clicking on the terminal). The interval function is keeping wrong data since it is not updating the CWD value. This small change listens to user data and will perform a CWD update when the user hits enter key.
Also, maybe the setInterval can be completely removed with this change.