### PR TITLE
Fix bottom margin in Hyper 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ exports.decorateConfig = (config) => {
     return Object.assign({}, config, {
         css: `
             ${config.css || ''}
-            .terms_terms {
+            .l_main {
                 margin-bottom: 30px;
             }
             .footer_footer {


### PR DESCRIPTION
I think the latest version of Hyper changed some of the classes, making the terminal text flow over the statusline. I made a one-line change that corrects that.