### PR TITLE
declare OS compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "hyper-statusline",
     "statusline"
   ],
+  "os": [
+    "!win32"
+  ],
   "dependencies": {
     "tildify": "^1.2.0"
   }


### PR DESCRIPTION
Hi, I love this plugin but spent a bit of time scratching my head when I went to use it on my windows machine. It seems that this is currently expected to not work on windows (#38). Perhaps it would be appropriate to declare as much in the package.json so wayward windows users are alerted when they attempt to install?