### PR TITLE
Fix: Prevent Override of Existing innerCustomChildren

### DIFF
--- a/index.js
+++ b/index.js
@@ -285,8 +285,8 @@ exports.decorateHyper = (Hyper, { React }) => {
         }
 
         render() {
-            const { customChildren } = this.props
-            const existingChildren = customChildren ? customChildren instanceof Array ? customChildren : [customChildren] : [];
+            const { customInnerChildren } = this.props
+            const existingChildren = customInnerChildren ? customInnerChildren instanceof Array ? customInnerChildren : [customInnerChildren] : [];
 
             return (
                 React.createElement(Hyper, Object.assign({}, this.props, {


### PR DESCRIPTION
Because the `existingChildren` check references `customChildren`
but the render uses the `customInnerChildren` property, this plugin
resets `customInnerChildren`, overriding previous children, thereby
preventing other extensions from rendering. Fixing the check to
inspect `customInnerChildren` allows this extension to co-exist with
other extensions leveraging the `customInnerChildren` property.