### PR TITLE
Fix bug that causes status line to be empty if Unix username has spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ const setCwd = (pid, action) => {
             }
         }
     } else {
-        exec(`lsof -p ${pid} | awk '$4=="cwd"' | tr -s ' ' | cut -d ' ' -f9-`, (err, stdout) => {
+        exec(`lsof -a -F -p ${pid} -d cwd | grep ^n | cut -c2-`, (err, stdout) => {
             cwd = stdout.trim();
             setGit(cwd);
         });


### PR DESCRIPTION
The current implementation for extracting the current working directory (cwd) fails for Unix when the username has a space. This causes the cwd string to be empty, which leads to a completely empty status line.

Specifically, `awk` retrieves the 4th field from the `lsof` output, but when the username has a space, cwd is actually the 5th, because of the additional whitespace.

The submitted patch circumvents this by using the `-F` option for `lsof` so that columns are returned as rows for increased machine-readability. The correct field is filtered by process id (`-p ${pid}`) and field identifier (`-d cwd`), where the `-a` option ensures the logical and of these filters. The output of `lsof` is then grepped to get the field with identifier `n` (name) as the first character. This identifier is finally removed with `cut`, so that the remaining string is the current working directory.

Tested with Hyper 2.0.0 on MacOS High Sierra 10.13.6