### PR TITLE
Use `--no-optional-locks` when checking git status.

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ const gitRemote = (repo, cb) => {
 }
 
 const gitDirty = (repo, cb) => {
-    exec(`git status --porcelain --ignore-submodules -uno`, { cwd: repo }, (err, stdout) => {
+    exec(`git --no-optional-locks status --porcelain --ignore-submodules -uno`, { cwd: repo }, (err, stdout) => {
         if (err) {
             return cb(err);
         }


### PR DESCRIPTION
Scripts running status in the background should use the `--no-optional-locks` to prevent opportunistic locking.

This should fix an issue where operations fail due to the index being locked by status updates. 

Fixes #32 